### PR TITLE
Use executable-find for sdcv path

### DIFF
--- a/lexic.el
+++ b/lexic.el
@@ -1833,7 +1833,7 @@ dictionary list. It has the form:
 Any cons cell here means using all dictionaries.
 ")
 
-(defvar lexic-program-path "/usr/bin/sdcv"
+(defvar lexic-program-path (executable-find "sdcv")
   "The path of lexic program.")
 
 (defvar lexic-dictionary-path nil


### PR DESCRIPTION
This case generalizes the `/usr/bin` case, and makes it work automatically when the executable isn't always there (nix/guix).