### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/lexic.el
+++ b/lexic.el
@@ -94,6 +94,10 @@
 (require 'dash)
 (require 'visual-fill-column)
 (require 'cl-lib)
+(require 'subr-x)
+(require 'display-line-numbers)
+
+(declare-function spell-fu-mode "spell-fu")
 
 ;;;;##################################################################
 ;;;;  User Options, Variables


### PR DESCRIPTION
```
In lexic-mode:
lexic.el:380:15:Warning: assignment to free variable
    ‘display-line-numbers-type’

In lexic-format-entry:
lexic.el:655:44:Warning: ‘(formatter (lexic-dictionary-spec dict :formatter))’
    is a malformed function
lexic.el:668:34:Warning: reference to free variable ‘formatter’

In end of data:
lexic.el:1904:1:Warning: the following functions are not known to be defined: spell-fu-mode,
    if-let*, string-trim, string-empty-p, string-join
```